### PR TITLE
Add basic Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+npm-debug.log
+node_modules
+*.swp
+*.swo
+data
+*.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
-npm-debug.log
 node_modules
+.vscode
+data
+data-test
+
 *.swp
 *.swo
-data
 *.DS_Store
+
+npm-debug.log
+static/*.min.js
+config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@ COPY . .
 
 RUN npm run build
 
-RUN npm install redis@0.8.1 && \
-    npm install pg@4.1.1 && \
-    npm install memcached@2.2.2 && \
-    npm install aws-sdk@2.738.0 && \
-    npm install rethinkdbdash@2.3.31
-
 ENV HOST 0.0.0.0
 
 EXPOSE 7777

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:lts-alpine
+
+RUN mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY . . 
+
+RUN npm run build
+
+RUN npm install redis@0.8.1 && \
+    npm install pg@4.1.1 && \
+    npm install memcached@2.2.2 && \
+    npm install aws-sdk@2.738.0 && \
+    npm install rethinkdbdash@2.3.31
+
+ENV HOST 0.0.0.0
+
+EXPOSE 7777
+STOPSIGNAL SIGINT
+ENTRYPOINT [ "node", "server.js" ]
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.0"
+services:
+  haste-server:
+    build: .
+    ports:
+      - 7777:7777
+    volumes:
+      - haste-data:/usr/src/app/data
+
+volumes: 
+  haste-data:


### PR DESCRIPTION
Adds a really basic Docker image. Improvements are definitely possible but would require more code changes I believe.

Currently installs all the storage peer dependencies, there's probably a better way to handle that. Separate images perhaps?

Has a basic docker-compose file as well which is set up to use the local file storage. Uses a volume for persistence.


Closes #8 