### PR TITLE
Rewrite Amazon S3, add Amazon DynamoDB and Cloudant in document stores

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -20,7 +20,31 @@ In alphabetical order:
 
 ## Amazon S3
 
-Not rewritten yet, to be filled in
+Stores documents in a specified s3 storage bucket.
+To use S3 compatible object storage, you must install `@aws-sdk/client-s3` via `npm` or `yarn`
+
+The bucket must be pre-create before running the server.
+Check [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html) for more `S3ClientConfig` options.
+
+```json
+{
+  "type": "amazon-s3",
+  "bucket": "bucketname",
+  "expire": 0,
+  "clientOptions": {
+    "region": "region-code",
+    "credentials": {
+      "accessKeyId": "access key id here",
+      "secretAccessKey": "super secret access key here"
+    },
+    // For custom endpoint or S3 compatible storage 
+    // like Minio, DigitalOcean Spaces, IBM Cloud Object Storage, Backblaze B2 cloud storage...
+    "endpoint": "https://custom.s3.endpoint",
+    // For Minio to work
+    "forcePathStyle": true
+  }
+}
+```
 
 
 ## File
@@ -123,4 +147,21 @@ Expiration property in config can be changed to a value in seconds after which e
 
 ## RethinkDB
 
-Not rewritten yet, to be filled in
+To use the RethinkDB storage system, you must install the `rethinkdbdash` package via `npm` or `yarn`
+
+Create a database and a table with with your preferred name, which will store all data.
+Replace `dbname` and `tablename` in config object below with the real name of database and table respectively.
+Check [documentation](https://github.com/neumino/rethinkdbdash#new-features-and-differences) for more config options.
+
+```json
+{
+  "type": "rethinkdb",
+  "table": "tablename",
+  "expire": 0,
+  "clientOptions": {
+    "host": "127.0.0.1",
+    "port": 28015,
+    "db": "dbname"
+  }
+}
+```

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -16,6 +16,8 @@ In alphabetical order:
 - [Postgres](#postgres)
 - [Redis](#redis)
 - [RethinkDB](#rethinkdb)
+- [Amazon DynamoDB](#amazon-dynamodb)
+- [Cloudant](#cloudant)
 
 
 ## Amazon S3
@@ -164,4 +166,54 @@ Check [documentation](https://github.com/neumino/rethinkdbdash#new-features-and-
     "db": "dbname"
   }
 }
+```
+
+## Amazon DynamoDB
+
+To use Amazon DynamoDB store, you must install `@aws-sdk/client-dynamodb` via `npm` or `yarn`
+
+The table must be pre-create before running the server.
+Check [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/interfaces/dynamodbclientconfig.html) for more `DynamoDBClientConfig` options.
+
+```json
+{
+  "type": "amazon-dynamodb",
+  "table": "tablename",
+  "expire": 0,
+  "clientOptions": {
+    "region": "region-code",
+    "credentials": {
+      "accessKeyId": "access key id here",
+      "secretAccessKey": "super secret access key here"
+    }
+  }
+}
+```
+
+## Cloudant
+
+To use S3 compatible object storage, you must install `@cloudant/cloudant` via `npm` or `yarn`
+
+Before start server, create a database with your preffered name.
+Check [documentation](https://github.com/cloudant/nodejs-cloudant/blob/master/README.md) for more detailed configuration.
+
+```json
+{
+  "type": "cloudant",
+  "db": "dbname",
+  "expire": 0,
+  "clientOptions": {
+    "url": "https://your.cloudant.service",
+    // If you use username and password for authentication
+    "username": "username",
+    "password": "password",
+    // If you use IBM Cloud's IAM API Key for authentication
+    "plugins": {
+      "iamauth": {
+        "iamApiKey": "your iam api key here"
+      }
+    }
+  }
+}
+
 ```

--- a/lib/document_stores/amazon-dynamodb.js
+++ b/lib/document_stores/amazon-dynamodb.js
@@ -1,0 +1,64 @@
+const { DynamoDBClient, GetItemCommand, PutItemCommand } = require('@aws-sdk/client-dynamodb');
+const winston = require('winston');
+
+class AmazonDynamoDBDocumentStore {
+	constructor(options) {
+		this.expire = options.expire;
+		this.table = options.table;
+		this.client = new DynamoDBClient(options.clientOptions);
+	}
+
+	async get(key, skipExpire) {
+		const _this = this;
+
+		const command = new GetItemCommand({
+			TableName: _this.table,
+			Key: {
+				key: {
+					S: key
+				}
+			},
+			AttributesToGet: ['value']
+		});
+		return await _this.client.send(command)
+			.then(output => {
+				if (_this.expire && !skipExpire) {
+					winston.warn('amazon dynamodb store cannot set expirations on keys');
+				}
+				return output.Item.value.S;
+			})
+			.catch(err => {
+				winston.error('failed to get amazon dynamodb document', { error: err });
+				return false;
+			});
+	}
+
+	async set(key, data, skipExpire) {
+		const _this = this;
+
+		const command = new PutItemCommand({
+			TableName: _this.table,
+			Item: {
+				key: {
+					S: key
+				},
+				value: {
+					S: data
+				}
+			},
+		});
+		return await _this.client.send(command)
+			.then(() => {
+				if (_this.expire && !skipExpire) {
+					winston.warn('amazon dynamodb store cannot set expirations on keys');
+				}
+				return true;
+			})
+			.catch(err => {
+				winston.error('failed to set amazon dynamodb document', { key: key, error: err });
+				return false;
+			});
+	}
+}
+
+module.exports = AmazonDynamoDBDocumentStore;

--- a/lib/document_stores/amazon-s3.js
+++ b/lib/document_stores/amazon-s3.js
@@ -1,54 +1,66 @@
-const AWS = require('aws-sdk');
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
 const winston = require('winston');
+const stream = require('stream');
+const { promisify } = require('util');
+class AmazonS3DocumentStore {
+	constructor(options) {
+		this.expire = options.expire || 0;
+		this.bucket = options.bucket;
+		this.client = new S3Client(options.clientOptions);
+	}
 
-const AmazonS3DocumentStore = function(options){
-	this.expire = options.expire;
-	this.bucket = options.bucket;
-	this.client = new AWS.S3({region: options.region});
-};
+	async get(key, skipExpire) {
+		const _this = this;
 
-AmazonS3DocumentStore.prototype.get = function(key, callback, skipExpire){
-	const _this = this;
+		const command = new GetObjectCommand({
+			Bucket: _this.bucket,
+			Key: key,
+			ResponseContentType: 'text/plain'
+		});
 
-	const req = {
-		Bucket: _this.bucket,
-		Key: key
-	};
+		return await _this.client.send(command)
+			.then(output => {
+				return new Promise((resolve) => {
+          let data = '';
+					output.Body.on('data', chunk => data += chunk.toString('utf-8'));
+          output.Body.on('end', () => resolve(data));
+					output.Body.on('error', () => resolve(false));
+					output.Body.read();
+					if (_this.expire && !skipExpire) {
+            _this.set(key, data, skipExpire)
+              .then(updateSucceeded => {
+                if (!updateSucceeded) {
+						      winston.warn('failed to update expirations on amazon s3 document');
+                }
+              })
+					}
+				});
+			})
+			.catch(err => {
+				winston.error('failed to get amazon s3 document', { error: err });
+				return false;
+			});
+	}
 
-	_this.client.getObject(req, function(err, data){
-		if(err){
-			callback(false);
-		}
-		else {
-			callback(data.Body.toString('utf-8'));
-			if (_this.expire && !skipExpire){
-				winston.warn('amazon s3 store cannot set expirations on keys');
-			}
-		}
-	});
-};
+	async set(key, data, skipExpire) {
+		const _this = this;
+		let now = new Date();
 
-AmazonS3DocumentStore.prototype.set = function(key, data, callback, skipExpire){
-	const _this = this;
-
-	const req = {
-		Bucket: _this.bucket,
-		Key: key,
-		Body: data,
-		ContentType: 'text/plain'
-	};
-
-	_this.client.putObject(req, function(err, data){
-		if (err){
-			callback(false);
-		}
-		else {
-			callback(true);
-			if (_this.expire && !skipExpire){
-				winston.warn('amazon s3 store cannot set expirations on keys');
-			}
-		}
-	});
-};
-
+		const command = new PutObjectCommand({
+			Bucket: _this.bucket,
+			Key: key,
+			Body: data,
+			ContentType: 'text/plain',
+			Expires: (_this.expire && !skipExpire) ? now.setSeconds(now.getSeconds() + _this.expire) : undefined
+		});
+		return await _this.client.send(command)
+			.then(() => {
+				return true;
+			})
+			.catch(err => {
+				winston.error('failed to set amazon s3 document', { key: key, error: err });
+				return false;
+			});
+	}
+}
 module.exports = AmazonS3DocumentStore;

--- a/lib/document_stores/cloudant.js
+++ b/lib/document_stores/cloudant.js
@@ -1,0 +1,56 @@
+const Cloudant = require('@cloudant/cloudant');
+const winston = require('winston');
+
+class CloudantStore {
+	constructor(options) {
+		this.db = options.db;
+		this.expire = options.expire;
+		this.client = Cloudant(options.clientOptions);
+	}
+
+	async get(key, skipExpire) {
+		const _this = this;
+
+		return await _this.client.use(_this.db).get(key)
+			.then(data => {
+				if (_this.expire && !skipExpire) {
+					winston.warn('cloudant cannot set expirations on keys');
+				}
+				return data.value;
+			})
+			.catch(err => {
+				winston.error('failed to get cloudant document', { error: err });
+				return false;
+			});
+	}
+
+	async set(key, data, skipExpire) {
+		const _this = this;
+
+		const doc = {
+			_id: key,
+			value: data
+		};
+		const etag = await _this.client.use(_this.db).head(key)
+			.then(head => {
+				return head ? head.etag.replace(/"/g, '') : '';
+			})
+			.catch(() => {
+				return '';
+			});
+		if (etag) doc['_rev'] = etag;
+		return await this.client.use(_this.db).insert(doc)
+			.then(() => {
+				if (_this.expire && !skipExpire) {
+					winston.warn('cloudant cannot set expirations on keys');
+				}
+				return true;
+			})
+			.catch(err => {
+				winston.error('failed to set cloudant document', { key: key, error: err });
+				return false;
+			});
+	}
+}
+
+module.exports = CloudantStore;

--- a/lib/document_stores/memcached.js
+++ b/lib/document_stores/memcached.js
@@ -25,26 +25,35 @@ class MemcachedDocumentStore {
 	}
 
 	// Save file in a key
-	set(key, data, callback, skipExpire){
-		this.client.set(key, data, skipExpire ? 0 : this.expire, (error) => {
-			callback(!error);
+	set(key, data, skipExpire){
+		return new Promise((resolve) => {
+			this.client.set(key, data, skipExpire ? 0 : this.expire, (error) => {
+				resolve(!error);
+			});
 		});
 	}
 
 	// Get a file from a key
-	get(key, callback, skipExpire){
-		this.client.get(key, (error, data) => {
-			callback(error ? false : data);
-
-			// Update the key so that the expiration is pushed forward
-			if (!skipExpire){
-				this.set(key, data, (updateSucceeded) => {
-					if (!updateSucceeded){
-						winston.error('failed to update expiration on GET', {key});
+	get(key, skipExpire){
+		return new Promise((resolve) => {
+			this.client.get(key, (error, data) => {
+				if (!error){
+					// Update the key so that the expiration is pushed forward
+					if (!skipExpire){
+						this.set(key, data, (updateSucceeded) => {
+							if (!updateSucceeded){
+								winston.error('failed to update expiration on GET', {key});
+							}
+						}, skipExpire);
 					}
-				}, skipExpire);
-			}
+					resolve(data);
+				} else {
+					winston.error('failed to set memcached document', { key: key, error });
+					resolve(false);
+				}
+			});
 		});
+
 	}
 
 }

--- a/lib/document_stores/rethinkdb.js
+++ b/lib/document_stores/rethinkdb.js
@@ -9,37 +9,32 @@ const md5 = (str) => {
 };
 
 class RethinkDBStore {
-	constructor(options){
-		this.client = rethink({
-			silent: true,
-			host: options.host || '127.0.0.1',
-			port: options.port || 28015,
-			db: options.db || 'haste',
-			user: options.user || 'admin',
-			password: options.password || ''
-		});
+	constructor(options) {
+		this.expire = options.expire;
+		this.table = options.table;
+		this.client = rethink(options.clientOptions);
 	}
 
-	set(key, data, callback){
-		this.client.table('uploads').insert({ id: md5(key), data: data }).run((error) => {
-			if (error){
-				callback(false);
-				winston.error('failed to insert to table', error);
-				return;
-			}
-			callback(true);
-		});
+	async set(key, data, skipExpire) {
+		return await this.client.table(this.table).insert({ id: md5(key), data: data }).run()
+			.then(() => {
+				return true;
+			})
+			.catch(err => {
+				winston.error('failed to insert to table', { error: err });
+				return false;
+			});
 	}
 
-	get(key, callback){
-		this.client.table('uploads').get(md5(key)).run((error, result) => {
-			if (error || !result){
-				callback(false);
-				if (error) winston.error('failed to insert to table', error);
-				return;
-			}
-			callback(result.data);
-		});
+	async get(key, skipExpire) {
+		return await this.client.table(this.table).get(md5(key)).run()
+			.then(result => {
+				return result.data;
+			})
+			.catch(err => {
+				winston.error('failed to insert to table', { error: err });
+				return false;
+			});
 	}
 }
 

--- a/server.js
+++ b/server.js
@@ -51,7 +51,8 @@ const utils = new HasteUtils();
 		winston.info('loading static document', { name: name, path: path });
 		let data = fs.readFileSync(path, 'utf8');
 		if (data){
-			await preferredStore.set(name, data, doc => winston.debug('loaded static document', { success: doc }), true);
+			const doc = await preferredStore.set(name, data, true);
+			winston.debug('loaded static document', { success: doc });
 		}
 		else {
 			winston.warn('failed to load static document', { name: name, path: path });


### PR DESCRIPTION
I made some changes in document stores:
- Rewrite `amazon-s3` using [aws-sdk-js-v3](https://github.com/aws/aws-sdk-js-v3)
- Promisify `memcached` store without significant changes.
- Promisify `rethinkdb` store, change connect options config.
- Add `amazon-dynamodb` and `cloudant` stores.